### PR TITLE
Update GitHub Actions to use Node 16

### DIFF
--- a/.github/workflows/gradleCI.yml
+++ b/.github/workflows/gradleCI.yml
@@ -17,6 +17,7 @@ jobs:
         with:
           distribution: 'adopt'
           java-version: 11
+          cache: 'gradle'
 
       - name: Build
         run: './gradlew build'

--- a/.github/workflows/gradleCI.yml
+++ b/.github/workflows/gradleCI.yml
@@ -10,18 +10,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
+          distribution: 'adopt'
           java-version: 11
 
       - name: Build
         run: './gradlew build'
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Generated Files
           path: ./build/libs/*

--- a/.github/workflows/gradleRelease.yml
+++ b/.github/workflows/gradleRelease.yml
@@ -81,7 +81,7 @@ jobs:
       uses: EndBug/add-and-commit@v9.1.3
       with:
         add: './robotlib.json'
-        branch: 'master'
+        new_branch: 'testing-branch-please-ignore'
         message: 'Automated - Update robotlib.json for release'
 
     - name: Upload robotlib.json to Release

--- a/.github/workflows/gradleRelease.yml
+++ b/.github/workflows/gradleRelease.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
+        cache: gradle
 
     - name: Build RobotLib
       run: './gradlew build'
@@ -73,6 +74,7 @@ jobs:
       with:
         distribution: 'adopt'
         java-version: 11
+        cache: gradle
 
     - name: Generate robotlib.json
       run: './gradlew vendorJSON'
@@ -81,7 +83,6 @@ jobs:
       uses: EndBug/add-and-commit@v9.1.3
       with:
         add: './robotlib.json'
-        new_branch: 'testing-branch-please-ignore'
         message: 'Automated - Update robotlib.json for release'
 
     - name: Upload robotlib.json to Release

--- a/.github/workflows/gradleRelease.yml
+++ b/.github/workflows/gradleRelease.yml
@@ -13,63 +13,49 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
 
     - name: Get Tag
-      uses: olegtarasov/get-tag@v2.1.1
+      uses: olegtarasov/get-tag@v2.1.2
       id: getTag
       with:
         tagRegex: "v(.*)" # This filters out the `v` from the tag. (Ex: v3.8.0 becomes 3.8.0)
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'adopt'
         java-version: 11
 
     - name: Build RobotLib
       run: './gradlew build'
 
-    - name: Get Release Upload URL
-      uses: actions/github-script@0.3.0
-      id: getReleaseURL
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const core = require('@actions/core')
-          core.setOutput("uploadurl",context.payload.release.upload_url)
-
     - name: Upload RobotLib Jar
       id: upload-release-asset 
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.getReleaseURL.outputs.uploadurl }} 
-        asset_path: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}.jar
+        repo_token: ${{ secrets.GITHUB_TOKEN }} 
+        file: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}.jar
         asset_name: RobotLib-${{ steps.getTag.outputs.tag }}.jar
-        asset_content_type: application/java-archive
+        tag: ${{ github.ref }}
 
     - name: Upload RobotLib JavaDoc Jar
       id: upload-release-asset-javadoc
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.getReleaseURL.outputs.uploadurl }} 
-        asset_path: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}-javadoc.jar
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}-javadoc.jar
         asset_name: RobotLib-${{ steps.getTag.outputs.tag }}-javadoc.jar
-        asset_content_type: application/java-archive
+        tag: ${{ github.ref }}
 
     - name: Upload RobotLib Sources Jar
       id: upload-release-asset-sources
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.getReleaseURL.outputs.uploadurl }} 
-        asset_path: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}-sources.jar
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./build/libs/RobotLib-${{ steps.getTag.outputs.tag }}-sources.jar
         asset_name: RobotLib-${{ steps.getTag.outputs.tag }}-sources.jar
-        asset_content_type: application/java-archive
+        tag: ${{ github.ref }}
 
 
   generateJSON:
@@ -80,39 +66,29 @@ jobs:
 
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up JDK 11
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v3
       with:
+        distribution: 'adopt'
         java-version: 11
 
     - name: Generate robotlib.json
       run: './gradlew vendorJSON'
 
     - name: Commit robotlib.json
-      uses: EndBug/add-and-commit@v7.3.0
+      uses: EndBug/add-and-commit@v9.1.3
       with:
         add: './robotlib.json'
         branch: 'master'
         message: 'Automated - Update robotlib.json for release'
 
-    - name: Get Release Upload URL
-      uses: actions/github-script@0.3.0
-      id: getReleaseURL
-      with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
-        script: |
-          const core = require('@actions/core')
-          core.setOutput("uploadurl",context.payload.release.upload_url)
-
     - name: Upload robotlib.json to Release
       id: upload-release-asset 
-      uses: actions/upload-release-asset@v1.0.1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      uses: svenstaro/upload-release-action@v2
       with:
-        upload_url: ${{ steps.getReleaseURL.outputs.uploadurl }} 
-        asset_path: ./robotlib.json
+        repo_token: ${{ secrets.GITHUB_TOKEN }}
+        file: ./robotlib.json
         asset_name: robotlib.json
-        asset_content_type: application/json
+        tag: ${{ github.ref }}


### PR DESCRIPTION
On May 18th, [GitHub is dropping support for actions using Node 12](https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/). As of the time of writing, both automated workflows will be impacted by this change.

This PR updates the actions being used to versions that use Node 16 or switches the actions used to ones that do support Node 16. There are no user/dev-facing changes.

In addition, dependency caching will also be enabled, reducing the runtime for builds. No action is required from ORF's software team to maintain the caching, it is automatically handled by GitHub Actions.

You can see an example of working runs using the links below:
A standard CI build: https://github.com/MoSadie/RobotLib/actions/runs/4963613831
A release build: https://github.com/MoSadie/RobotLib/actions/runs/4963613830
The test release: https://github.com/MoSadie/RobotLib/releases/tag/v4.5.0