### PR TITLE
Fix robotlib.json generator

### DIFF
--- a/.github/workflows/gradleRelease.yml
+++ b/.github/workflows/gradleRelease.yml
@@ -58,38 +58,50 @@ jobs:
         asset_name: RobotLib-${{ steps.getTag.outputs.tag }}-sources.jar
         tag: ${{ github.ref }}
 
-
-  generateJSON:
-    # The build job (above) must complete successfully in order for this job to run.
-    needs: build
-
-    runs-on: ubuntu-latest
-
-    steps:
-    - name: Checkout Repository
-      uses: actions/checkout@v3
-
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        distribution: 'adopt'
-        java-version: 11
-        cache: gradle
-
     - name: Generate robotlib.json
       run: './gradlew vendorJSON'
 
-    - name: Commit robotlib.json
-      uses: EndBug/add-and-commit@v9.1.3
-      with:
-        add: './robotlib.json'
-        message: 'Automated - Update robotlib.json for release'
-
     - name: Upload robotlib.json to Release
-      id: upload-release-asset 
+      id: upload-release-asset-json
       uses: svenstaro/upload-release-action@v2
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ./robotlib.json
         asset_name: robotlib.json
         tag: ${{ github.ref }}
+
+    - name: Upload robotlib.json to Artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: robotlib.json
+        path: ./robotlib.json
+
+
+  commitJSON:
+    # The build job (above) must complete successfully in order for this job to run.
+    needs: build
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+    - name: Download robotlib.json
+      uses: actions/download-artifact@v4
+      with:
+        name: robotlib.json
+        path: ${{ runner.temp }}
+
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+      with:
+        ref: "ignore-me-json-testing" # TODO: Change to master
+
+    - name: Move robotlib.json
+      run: mv ${{ runner.temp }}/robotlib.json ${{ github.workspace }}/robotlib.json
+
+    
+    - name: Commit robotlib.json
+      uses: EndBug/add-and-commit@v9.1.3
+      with:
+        add: './robotlib.json'
+        message: 'Automated - Update robotlib.json for release'

--- a/.github/workflows/gradleRelease.yml
+++ b/.github/workflows/gradleRelease.yml
@@ -94,7 +94,7 @@ jobs:
     - name: Checkout Repository
       uses: actions/checkout@v4
       with:
-        ref: "ignore-me-json-testing" # TODO: Change to master
+        ref: "master"
 
     - name: Move robotlib.json
       run: mv ${{ runner.temp }}/robotlib.json ${{ github.workspace }}/robotlib.json
@@ -104,4 +104,4 @@ jobs:
       uses: EndBug/add-and-commit@v9.1.3
       with:
         add: './robotlib.json'
-        message: 'Automated - Update robotlib.json for release'
+        message: 'Automated - Update robotlib.json'

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,6 @@ else {
 					// The release action will update robolib.json to the new version on github.
 					// After release action is complete you can fetch from github with tags to 
 					// get the updated robotlib.json and release tag back into the local git repo.
-					// Note: as of 1-16-24, this step is not working. So after successful release,
-					// manually update RobotLib.json to the new version and push it to github.
 					//
 					// When all this is done, other user's robot projects that want the updated
 					// RobotLib, edit their local RobotLib.json to reflect the new version number 
@@ -69,9 +67,6 @@ else {
 					//
 					// Or if using VSCode, run the Manage Vendor Libraries (online) command and 
 					// it will detect the new RobotLib version and offer to update the VSCode project.
-					//
-					// Warning: The github release action only works on the master branch. Do not
-					// create releases from other branches.
 					//
 					// Note: the github action files gradleCI.yml and gradleRelease.yml are
 					// located in .github\workflows.


### PR DESCRIPTION
Reworked how the robotlib.json file is generated and pushed, allowing the ability to create releases from any branch, automatically updating the master branch's robotlib.json file.

Long Version:
- Moved the generation of the robotlib.json file to be with the main build step, including the uploading to the release. Added a new step that uploads robotlib.json as a build artifact to the run, which allows us to download it easily later.
- Changed generateJSON job to commitJSON, which now does this:
  - Download the robotlib.json to a temporary directory
  - Download the master branch of the repo
  - Overwrite the robotlib.json with the new one
  - Commit and push the changes to master. (If needed the branch to push the updated robotlib.json to can be changed on line 97)


Example Run: https://github.com/MoSadie/RobotLib/actions/runs/7587314051