### PR TITLE
Add support for DataLog logging of `Util.consoleLog(...)` calls

### DIFF
--- a/.project
+++ b/.project
@@ -24,22 +24,22 @@
 		<link>
 			<name>gradle/gradleCI.yml</name>
 			<type>1</type>
-			<location>C:/Users/rcorn/workspace/FRC Java/RobotLib/.github/workflows/gradleCI.yml</location>
+			<location>/Users/cole/FRC/RobotLib/C::/Users/rcorn/workspace/FRC Java/RobotLib/.github/workflows/gradleCI.yml</location>
 		</link>
 		<link>
 			<name>gradle/gradleRelease.yml</name>
 			<type>1</type>
-			<location>C:/Users/rcorn/workspace/FRC Java/RobotLib/.github/workflows/gradleRelease.yml</location>
+			<location>/Users/cole/FRC/RobotLib/C::/Users/rcorn/workspace/FRC Java/RobotLib/.github/workflows/gradleRelease.yml</location>
 		</link>
 	</linkedResources>
 	<filteredResources>
 		<filter>
-			<id>1654560228124</id>
+			<id>1706034181273</id>
 			<name></name>
 			<type>30</type>
 			<matcher>
 				<id>org.eclipse.core.resources.regexFilterMatcher</id>
-				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
 			</matcher>
 		</filter>
 	</filteredResources>

--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -20,7 +20,7 @@ public class DataLogHandler extends Handler {
 
     /**
      * Default constructor to create a {@code DataLogHandler} object with the default
-     * {@log DataLogEntry} key of "UtilConsoleLog"
+     * {@code DataLogEntry} key of "UtilConsoleLog"
      */
     public DataLogHandler() {
         this("UtilConsoleLog");
@@ -29,7 +29,7 @@ public class DataLogHandler extends Handler {
 
     /**
      * Constructor to create a {@code DataLogHandler} object with the specified
-     * {@log DataLogEntry} key
+     * {@code DataLogEntry} key
      * 
      * @param key the key to be used when logging to the current {@code DataLog}
      */

--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -7,23 +7,60 @@ import edu.wpi.first.util.datalog.StringLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;
 
 /**
- * Publishes values to a DataLog
+ * 
+ * A custom implementation of Java's Log {@link Handler} that allows formatted
+ * log entries to be appended to the current {@code DataLog} which will be saved
+ * to RoboRio USB drive for later use in AdvantageScope log replay.
+ * 
+ * @since 4.8.3
+ * @author Cole Wilson
  */
 public class DataLogHandler extends Handler {
     private StringLogEntry dataLogEntry;
 
+    /**
+     * Default constructor to create a {@code DataLogHandler} object with the default
+     * {@log DataLogEntry} key of "UtilConsoleLog"
+     */
     public DataLogHandler() {
-        dataLogEntry = new StringLogEntry(DataLogManager.getLog(), "UtilConsoleLog");
+        this("UtilConsoleLog");
     }
 
+
+    /**
+     * Constructor to create a {@code DataLogHandler} object with the specified
+     * {@log DataLogEntry} key
+     * 
+     * @param key the key to be used when logging to the current {@code DataLog}
+     */
+    public DataLogHandler(String key) {
+        dataLogEntry = new StringLogEntry(DataLogManager.getLog(), "key");
+    }
+
+    /**
+     * Publish the given {@link LogRecord} to the current {@code DataLog} under the
+     * pre-specified key in the constructor (or default key of "UtilConsoleLog"). This method
+     * will auto-format the record using the formatter specified previously with
+     * {@link DataLogHandler#setFormatter(java.util.logging.Formatter)}.
+     * 
+     * @param record the {@code LogRecord} to be published
+     */
     @Override
     public void publish(LogRecord record) {
         dataLogEntry.append(getFormatter().format(record));
     }
     
+    /** 
+     * Does nothing, as the {@code DataLog} object does not need to be closed,
+     * but still must be defined.
+     */
     @Override
     public void close() throws SecurityException {}
 
+    /**
+     * Does nothing, as the flushing the stream is handled by the {@code DataLogManager}
+     * but is required to be defined.
+    */
     @Override
     public void flush() {}
 }

--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -1,0 +1,5 @@
+package Team4450.Lib;
+
+public class DataLogHandler {
+
+}

--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -1,5 +1,30 @@
 package Team4450.Lib;
 
-public class DataLogHandler {
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+import java.util.logging.StreamHandler;
 
+import edu.wpi.first.util.datalog.StringLogEntry;
+import edu.wpi.first.wpilibj.DataLogManager;
+
+/**
+ * Publishes values to a DataLog
+ */
+public class DataLogHandler extends Handler {
+    private StringLogEntry dataLogEntry;
+
+    public DataLogHandler() {
+        dataLogEntry = new StringLogEntry(DataLogManager.getLog(), "UtilConsoleLog");
+    }
+
+    @Override
+    public void publish(LogRecord record) {
+        dataLogEntry.append(getFormatter().format(record));
+    }
+    
+    @Override
+    public void close() throws SecurityException {}
+
+    @Override
+    public void flush() {}
 }

--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -2,7 +2,6 @@ package Team4450.Lib;
 
 import java.util.logging.Handler;
 import java.util.logging.LogRecord;
-import java.util.logging.StreamHandler;
 
 import edu.wpi.first.util.datalog.StringLogEntry;
 import edu.wpi.first.wpilibj.DataLogManager;

--- a/src/main/java/Team4450/Lib/Util.java
+++ b/src/main/java/Team4450/Lib/Util.java
@@ -17,6 +17,7 @@ import java.util.logging.Handler;
 import java.util.logging.FileHandler;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
 //import java.util.logging.SimpleFormatter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
@@ -133,6 +134,7 @@ public class Util
 	public static class CustomLogger 
 	{
         static private FileHandler 		fileTxt;
+		static private DataLogHandler   wpiLog;
         //static private SimpleFormatter	formatterTxt;
         static private LogFormatter		logFormatter;
         
@@ -206,10 +208,13 @@ public class Util
             	new File(path + "Logging.txt.99").delete();
 
             fileTxt = new AsyncFileHandler(path + "Logging.txt", 0, 99);
-            
             fileTxt.setFormatter(logFormatter);
+
+			wpiLog = new DataLogHandler();
+			wpiLog.setFormatter(logFormatter);
             
             logger.addHandler(fileTxt);
+			logger.addHandler(wpiLog);
         }
         
     	/**

--- a/src/main/java/Team4450/Lib/Util.java
+++ b/src/main/java/Team4450/Lib/Util.java
@@ -209,12 +209,18 @@ public class Util
 
             fileTxt = new AsyncFileHandler(path + "Logging.txt", 0, 99);
             fileTxt.setFormatter(logFormatter);
+			logger.addHandler(fileTxt);
 
+			// setup a DataLogHandler to log console messages to
+			// the RoboRio USB drive for log replay in AdvantageScope
 			wpiLog = new DataLogHandler();
 			wpiLog.setFormatter(logFormatter);
-            
-            logger.addHandler(fileTxt);
 			logger.addHandler(wpiLog);
+
+			// start the DataLogManager to begin recording networktables
+			// and joystick values
+			DataLogManager.start();
+			DriverStation.startDataLog(DataLogManager.getLog()); // (for joysticks)
         }
         
     	/**

--- a/src/main/java/Team4450/Lib/Util.java
+++ b/src/main/java/Team4450/Lib/Util.java
@@ -28,6 +28,7 @@ import java.nio.ByteOrder;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 
+import edu.wpi.first.wpilibj.DataLogManager;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.RobotBase;


### PR DESCRIPTION
This PR adds built-in support in RobotLib for logging calls to `Util.consoleLog` to be copied to the current DataLogManager under the `UtilConsoleLog` field. This enables log replay in AdvantageScope and merges console output with NT recording on local RoboRio USB drive.