### PR TITLE
Update vendorJSON to 1.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
 	id "edu.wpi.first.GradleRIO" version "2024.1.1"
     id "org.ajoberstar.grgit" version "3.0.0"
     id "maven-publish"
-    id "io.github.mosadie.vendorJSON" version "1.0"
+    id "io.github.mosadie.vendorJSON" version "1.1"
 }
 
 group = archivesGroup


### PR DESCRIPTION
Fixes missing frcYear from generated robotlib.json file.

Please test locally before the next release. (using the `vendorJSON` task)