### PR TITLE
Remove quotes to support custom keys

### DIFF
--- a/src/main/java/Team4450/Lib/DataLogHandler.java
+++ b/src/main/java/Team4450/Lib/DataLogHandler.java
@@ -33,7 +33,7 @@ public class DataLogHandler extends Handler {
      * @param key the key to be used when logging to the current {@code DataLog}
      */
     public DataLogHandler(String key) {
-        dataLogEntry = new StringLogEntry(DataLogManager.getLog(), "key");
+        dataLogEntry = new StringLogEntry(DataLogManager.getLog(), key);
     }
 
     /**


### PR DESCRIPTION
While this didn't really cause an issue before, it meant that logs were being filed under the literal STRING "key" rather than the VARIABLE `key` (more of an annoyance than a problem for this year) due to a bug in my earlier code PR. I just wanted to fix this for next season!